### PR TITLE
Add logos to project buttons and update Hyades link

### DIFF
--- a/index.html
+++ b/index.html
@@ -485,6 +485,18 @@
             fill: currentColor;
         }
 
+        .button-logo {
+            width: 1em;
+            height: 1em;
+            margin-right: 0.25em;
+            vertical-align: text-bottom;
+            fill: currentColor;
+        }
+
+        .github-icon {
+            color: var(--text-primary);
+        }
+
 
         .project-links a {
             display: inline-block;
@@ -1160,6 +1172,9 @@
                             </svg>
                         </a>
                         <a href="https://apps.apple.com/us/app/kayber/id6670231752" target="_blank">
+                            <svg class="button-logo" viewBox="0 0 24 24" aria-hidden="true">
+                                <text x="12" y="16" text-anchor="middle" font-size="16" font-family="sans-serif" fill="currentColor"></text>
+                            </svg>
                             Visit App Store
                             <svg class="external-link-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                                 <path d="M18 13v6a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" fill="none" stroke="currentColor" stroke-width="2"/>
@@ -1168,6 +1183,9 @@
                             </svg>
                         </a>
                         <a href="https://play.google.com/store/apps/details?id=com.kaybermobile" target="_blank">
+                            <svg class="button-logo" viewBox="0 0 24 24" aria-hidden="true">
+                                <path fill="currentColor" d="M3 2l18 10-18 10V2zm2 3.5v13l9.5-6.5L5 5.5z"/>
+                            </svg>
                             Visit Play Store
                             <svg class="external-link-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                                 <path d="M18 13v6a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" fill="none" stroke="currentColor" stroke-width="2"/>
@@ -1215,6 +1233,9 @@
                             </svg>
                         </a>
                         <a href="https://thetech.com/2024/05/09/ml-education-in-schools" target="_blank">
+                            <svg class="button-logo" viewBox="0 0 24 24" aria-hidden="true">
+                                <text x="12" y="16" text-anchor="middle" font-size="16" font-family="serif" fill="currentColor">T</text>
+                            </svg>
                             View News Article
                             <svg class="external-link-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                                 <path d="M18 13v6a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" fill="none" stroke="currentColor" stroke-width="2"/>
@@ -1290,7 +1311,7 @@
                         </ul>
                     </div>
                     <div class="project-links">
-                        <a href="https://maclea.mit.edu/about/" target="_blank">
+                        <a href="https://hyades.mit.edu" target="_blank">
                             Visit Hyades
                             <svg class="external-link-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                                 <path d="M18 13v6a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" fill="none" stroke="currentColor" stroke-width="2"/>
@@ -1374,7 +1395,10 @@
                     </ul>
                     <div class="project-links">
                         <a href="https://github.com/WesleyBLDC/corgi_hackathon" target="_blank">
-                            View Source Code 
+                            <svg class="button-logo github-icon" viewBox="0 0 16 16" aria-hidden="true">
+                                <path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.01.08-2.1 0 0 .67-.21 2.2.82A7.68 7.68 0 018 4.58a7.7 7.7 0 011.99.27c1.53-1.04 2.2-.82 2.2-.82.44 1.09.16 1.9.08 2.1.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+                            </svg>
+                            View Source Code
                             <svg class="external-link-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                                 <path d="M18 13v6a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" fill="none" stroke="currentColor" stroke-width="2"/>
                                 <polyline points="15 3 21 3 21 9" fill="none" stroke="currentColor" stroke-width="2"/>
@@ -1401,6 +1425,9 @@
                     </ul>
                     <div class="project-links">
                         <a href="https://kbrought.itch.io/mole-maker" target="_blank">
+                            <svg class="button-logo" viewBox="0 0 24 24" aria-hidden="true">
+                                <path fill="currentColor" d="M4 8c-1.1 0-2 .9-2 2v4c0 1.1.9 2 2 2h3l2 2h6l2-2h3c1.1 0 2-.9 2-2v-4c0-1.1-.9-2-2-2H4zm3 3h2v2H7v2H5v-2H3v-2h2V9h2v2zm9 1a1 1 0 112 0 1 1 0 01-2 0zm2 2a1 1 0 110-2 1 1 0 010 2z"/>
+                            </svg>
                             Play Game
                             <svg class="external-link-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
                                 <path d="M18 13v6a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" fill="none" stroke="currentColor" stroke-width="2"/>


### PR DESCRIPTION
## Summary
- add reusable button-logo style and white GitHub icon
- show GitHub, itch.io, App Store, Play Store, and The Tech logos on relevant project buttons
- fix Hyades project link to hyades.mit.edu

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68992b8f64f48323bedf44eb53adc294